### PR TITLE
Save HTTPS clone Link instead of ssh clone link

### DIFF
--- a/portfolio_backend/lib/GithubApi.cs
+++ b/portfolio_backend/lib/GithubApi.cs
@@ -8,7 +8,7 @@ namespace portfolio_backend.Lib{
 
     static class GithubApi {
 
-        private const String GH_PERSONAL_ACCESS_TOKEN = "git api key here";
+        private const String GH_PERSONAL_ACCESS_TOKEN = "github PAT";
 
         private static HttpClient client = new HttpClient();
 
@@ -26,7 +26,7 @@ namespace portfolio_backend.Lib{
             foreach(JObject obj in JArray.Parse(rawJson)){
                 if(obj["name"] == null) continue;
 
-                repositories.Add(new Repository(obj["name"]!.ToString(), obj["ssh_url"]!.ToString()));
+                repositories.Add(new Repository(obj["name"]!.ToString(), obj["clone_url"]!.ToString()));
             };
 
             return repositories;


### PR DESCRIPTION
For GitHub repository cloning logic we will use HTTPS instead of git, because on https we can authenticate with out Github Personal access token.
When using SSH we have to use an SSH Key which is not supported from `libgit2sharp` yet.
Also it is easier to use an authentication method which is already used on another place of this project