### PR TITLE
Fix: Tags will be appended not merged each repo update

### DIFF
--- a/portfolio_backend/Services/RepoUpdateService.cs
+++ b/portfolio_backend/Services/RepoUpdateService.cs
@@ -191,24 +191,27 @@ namespace portfolio_backend.Services{
             config = sr.ReadToEnd();
 
             JsonConfig configObject = JsonSerializer.Deserialize<JsonConfig>(config);
+            string[] persistedTags = JsonSerializer.Deserialize<string[]>(doc.Tags);
 
             if (configObject == null) return;
 
             doc.DocumentName = configObject.DocumentName;
             doc.Description = configObject.Description;
 
-            foreach (string tag in configObject.Tags)
-            {
-                
-                // if((Array.Find(doc.Tags, (string currentTag) => currentTag == tag))){
-                //     continue;
-                // };
+            //Console.WriteLine(persistedTags);
 
-                Console.WriteLine(doc.Tags);
+            // foreach (string tag in configObject.Tags)
+            // {
 
-                
-                doc.AddTag(tag);
-            }
+            //     if(Array.Find(persistedTags, (string currentTag) => currentTag == tag)){
+            //         continue;
+            //     };
+
+            //     Console.WriteLine(doc.Tags);
+
+
+            //     doc.AddTag(tag);
+            // }
         }
 
     }

--- a/portfolio_backend/Services/RepoUpdateService.cs
+++ b/portfolio_backend/Services/RepoUpdateService.cs
@@ -201,25 +201,9 @@ namespace portfolio_backend.Services{
             foreach (string tag in configObject.Tags)
             {
                 Console.WriteLine(tag == "planning");
-                // if(Array.Find(persistedTags, (string currentTag) => currentTag == tag)){
-                //     continue;
-                // };
-
-                bool found = false;
-                foreach (string persistedTag in persistedTags)
-                {
-                    if (persistedTag == tag)
-                    {
-                        found = true;
-                    }
-                }
-
-                if (found)
-                {
+                if(Array.Find(persistedTags, (string currentTag) => currentTag == tag) != null){
                     continue;
-                }
-
-
+                };
 
                 doc.AddTag(tag);
             }

--- a/portfolio_backend/Services/RepoUpdateService.cs
+++ b/portfolio_backend/Services/RepoUpdateService.cs
@@ -198,20 +198,31 @@ namespace portfolio_backend.Services{
             doc.DocumentName = configObject.DocumentName;
             doc.Description = configObject.Description;
 
-            //Console.WriteLine(persistedTags);
+            foreach (string tag in configObject.Tags)
+            {
+                Console.WriteLine(tag == "planning");
+                // if(Array.Find(persistedTags, (string currentTag) => currentTag == tag)){
+                //     continue;
+                // };
 
-            // foreach (string tag in configObject.Tags)
-            // {
+                bool found = false;
+                foreach (string persistedTag in persistedTags)
+                {
+                    if (persistedTag == tag)
+                    {
+                        found = true;
+                    }
+                }
 
-            //     if(Array.Find(persistedTags, (string currentTag) => currentTag == tag)){
-            //         continue;
-            //     };
+                if (found)
+                {
+                    continue;
+                }
 
-            //     Console.WriteLine(doc.Tags);
 
 
-            //     doc.AddTag(tag);
-            // }
+                doc.AddTag(tag);
+            }
         }
 
     }

--- a/portfolio_backend/Services/RepoUpdateService.cs
+++ b/portfolio_backend/Services/RepoUpdateService.cs
@@ -199,6 +199,14 @@ namespace portfolio_backend.Services{
 
             foreach (string tag in configObject.Tags)
             {
+                
+                // if((Array.Find(doc.Tags, (string currentTag) => currentTag == tag))){
+                //     continue;
+                // };
+
+                Console.WriteLine(doc.Tags);
+
+                
                 doc.AddTag(tag);
             }
         }

--- a/portfolio_backend/Services/RepoUpdateService.cs
+++ b/portfolio_backend/Services/RepoUpdateService.cs
@@ -200,8 +200,7 @@ namespace portfolio_backend.Services{
 
             foreach (string tag in configObject.Tags)
             {
-                Console.WriteLine(tag == "planning");
-                if(Array.Find(persistedTags, (string currentTag) => currentTag == tag) != null){
+                if(persistedTags.Contains(tag)){
                     continue;
                 };
 


### PR DESCRIPTION
Bei jedem ausgelösten Update werden die Tags nicht ergänzt (falls neue tags dazu kommen) sondern werden einfach neu an die alten Tags mit drangehangen.
Dies führt dazu, das die Liste an Tags mit jedem Update nochmal alle tags angehangen bekommt. 